### PR TITLE
[codex] 애니메이션 지연 업데이트를 Task 기반으로 전환

### DIFF
--- a/Sources/AnimateNumberText/Public/AnimateNumberText.swift
+++ b/Sources/AnimateNumberText/Public/AnimateNumberText.swift
@@ -25,6 +25,14 @@ public struct AnimateNumberText: View {
   // MARK: - Animation Properties
   @State
   private var animationRange: [TextType] = []
+
+  @State
+  private var animationUpdateTask: Task<Void, Never>?
+
+  private enum AnimationTiming {
+    static let resizeDuration: TimeInterval = 0.05
+    static let resizeDelayNanoseconds: UInt64 = 50_000_000
+  }
   
   /// Creates an animated number text view.
   ///
@@ -100,13 +108,22 @@ public struct AnimateNumberText: View {
       settingAnimationRange(stringValue, isAnimate: false)
     }
     .onChange(of: value) { newValue in
-      // MARK: - Handling Addition/Removal to Extra Value
-      let stringValue = formatter.string(from: newValue)
-      resizeAnimationRange(to: stringValue.count, duration: 0.05)
-      
-      DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-        settingAnimationRange(stringValue, isAnimate: true)
-      }
+      scheduleAnimationUpdate(for: newValue)
+    }
+    .onDisappear {
+      animationUpdateTask?.cancel()
+    }
+  }
+
+  private func scheduleAnimationUpdate(for newValue: Double) {
+    let stringValue = formatter.string(from: newValue)
+    resizeAnimationRange(to: stringValue.count,
+                         duration: AnimationTiming.resizeDuration)
+    animationUpdateTask?.cancel()
+    animationUpdateTask = Task { @MainActor in
+      try? await Task.sleep(nanoseconds: AnimationTiming.resizeDelayNanoseconds)
+      guard !Task.isCancelled else { return }
+      settingAnimationRange(stringValue, isAnimate: true)
     }
   }
   

--- a/Sources/AnimateNumberText/Public/AnimateNumberText.swift
+++ b/Sources/AnimateNumberText/Public/AnimateNumberText.swift
@@ -26,9 +26,6 @@ public struct AnimateNumberText: View {
   @State
   private var animationRange: [TextType] = []
 
-  @State
-  private var animationUpdateTask: Task<Void, Never>?
-
   private enum AnimationTiming {
     static let resizeDuration: TimeInterval = 0.05
     static let resizeDelayNanoseconds: UInt64 = 50_000_000
@@ -107,24 +104,24 @@ public struct AnimateNumberText: View {
       animationRange = Array(repeating: .string(""), count: stringValue.count)
       settingAnimationRange(stringValue, isAnimate: false)
     }
-    .onChange(of: value) { newValue in
-      scheduleAnimationUpdate(for: newValue)
-    }
-    .onDisappear {
-      animationUpdateTask?.cancel()
+    .task(id: value) {
+      await scheduleAnimationUpdate(for: value)
     }
   }
 
-  private func scheduleAnimationUpdate(for newValue: Double) {
+  @MainActor
+  private func scheduleAnimationUpdate(for newValue: Double) async {
     let stringValue = formatter.string(from: newValue)
     resizeAnimationRange(to: stringValue.count,
                          duration: AnimationTiming.resizeDuration)
-    animationUpdateTask?.cancel()
-    animationUpdateTask = Task { @MainActor in
-      try? await Task.sleep(nanoseconds: AnimationTiming.resizeDelayNanoseconds)
-      guard !Task.isCancelled else { return }
-      settingAnimationRange(stringValue, isAnimate: true)
+
+    do {
+      try await Task.sleep(nanoseconds: AnimationTiming.resizeDelayNanoseconds)
+    } catch {
+      return
     }
+
+    settingAnimationRange(stringValue, isAnimate: true)
   }
   
   private func resizeAnimationRange(to count: Int, duration: TimeInterval) {


### PR DESCRIPTION
## 변경 사항

- `DispatchQueue.main.asyncAfter`로 예약하던 애니메이션 문자열 반영을 `Task.sleep` 기반 흐름으로 전환했습니다.
- 값이 빠르게 변경될 때 이전 `animationUpdateTask`를 취소하고 최신 값만 반영하도록 했습니다.
- `onDisappear`에서 예약된 작업을 취소해 view 생명주기와 맞지 않는 지연 업데이트 가능성을 줄였습니다.
- 기존 0.05초 resize 지연과 애니메이션 timing은 유지했습니다.

## 배경

PR #4 리뷰에서 `DispatchQueue.main.asyncAfter(deadline: .now() + 0.05)`가 기기 상태나 프레임레이트에 따라 타이밍이 어긋날 수 있고, Swift 6 Strict Concurrency 관점에서 `Task`/`MainActor` 기반 흐름을 후속으로 검토하자는 지적이 있었습니다.

이번 PR은 공개 API를 바꾸지 않고 해당 지연 업데이트 경로만 좁게 정리합니다.

## 영향

- 사용자는 기존과 동일하게 `AnimateNumberText`를 사용할 수 있습니다.
- 빠른 값 변경 상황에서 오래된 예약 업데이트가 뒤늦게 반영될 가능성이 줄어듭니다.
- SwiftUI view가 사라진 뒤 지연 작업이 계속 실행되는 경로를 줄입니다.

## 보류한 항목

- `FormatStyle` 기반 새 API는 별도 공개 API 설계와 문서/테스트 확장이 필요하므로 이번 PR에 포함하지 않았습니다.
- Docstring coverage 정책 조정은 자동 품질 기준과 문서화 범위를 함께 정해야 하므로 별도 문서 PR로 분리하는 편이 낫다고 판단했습니다.

## 검증

- `swift test` 통과
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warn-concurrency` 통과
- `swift build -Xswiftc -strict-concurrency=complete -Xswiftc -warn-concurrency -Xswiftc -warnings-as-errors` 통과
- `git diff --check` 통과